### PR TITLE
Typescript support

### DIFF
--- a/typings/declaration.d.ts
+++ b/typings/declaration.d.ts
@@ -1,0 +1,5 @@
+declare module 'humanize-graphql-response' {
+  function humanize(response: object): object;
+
+  export default humanize;
+}


### PR DESCRIPTION
Using this library in typescript gives type error due to lack of declaration file, being necessary to create it in every typescript project you use.

Created a declaration file at directory typings/ to provide native support to typescript.